### PR TITLE
Set socket type on received socket

### DIFF
--- a/src/Tmds.Systemd/ServiceManager.Socket.cs
+++ b/src/Tmds.Systemd/ServiceManager.Socket.cs
@@ -108,6 +108,9 @@ namespace Tmds.Systemd
             // internal EndPoint _rightEndPoint;
             reflectionMethods.RightEndPoint.SetValue(socket, endPoint);
 
+            int sockType = GetSockOpt(fd, SO_TYPE);
+            reflectionMethods.SocketType.SetValue(socket, sockType);
+
             return (Socket)socket;
         }
 
@@ -117,6 +120,7 @@ namespace Tmds.Systemd
             public ConstructorInfo SocketConstructor;
             public FieldInfo RightEndPoint;
             public FieldInfo IsListening;
+            public FieldInfo SocketType;
             public ConstructorInfo UnixDomainSocketEndPointConstructor;
         }
 
@@ -148,6 +152,11 @@ namespace Tmds.Systemd
             {
                 ThrowNotSupported(nameof(isListening));
             }
+            FieldInfo socketType = typeof(Socket).GetTypeInfo().GetField("_socketType", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            if (socketType == null)
+            {
+                ThrowNotSupported(nameof(socketType));
+            }
             Assembly pipeStreamAssembly = typeof(PipeStream).GetTypeInfo().Assembly;
             Type unixDomainSocketEndPointType = pipeStreamAssembly.GetType("System.Net.Sockets.UnixDomainSocketEndPoint");
             if (unixDomainSocketEndPointType == null)
@@ -165,6 +174,7 @@ namespace Tmds.Systemd
                 SocketConstructor = socketConstructor,
                 RightEndPoint = rightEndPoint,
                 IsListening = isListening,
+                SocketType = socketType,
                 UnixDomainSocketEndPointConstructor = unixDomainSocketEndPointConstructor
             };
         }

--- a/test/Tmds.Systemd.Tests/SocketTests.cs
+++ b/test/Tmds.Systemd.Tests/SocketTests.cs
@@ -82,6 +82,9 @@ namespace Tmds.Systemd.Tests
                 Socket[] sockets = fds.GetListenSockets(fds[0], fds.Count);
                 foreach (Socket server in sockets)
                 {
+                    Assert.Equal(server.SocketType, SocketType.Stream);
+                    Assert.Equal(server.AddressFamily, AddressFamily.InterNetwork);
+                    Assert.Equal(server.ProtocolType, ProtocolType.Tcp);
                     using (var client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
                     {
                         client.Connect(server.LocalEndPoint);


### PR DESCRIPTION
The received socket had type Unknown which didn't allow me to use NetworkStream to write to it. I now set the socket type base on GetSockOpt.