### PR TITLE
GetListenSockets: use Process.Id instead of Process.Handle (fix for 3.0)

### DIFF
--- a/src/Tmds.Systemd/ServiceManager.Socket.cs
+++ b/src/Tmds.Systemd/ServiceManager.Socket.cs
@@ -61,7 +61,7 @@ namespace Tmds.Systemd
                     return Array.Empty<Socket>();
                 }
                 string listenPid = Environment.GetEnvironmentVariable(LISTEN_PID);
-                string myPid = Process.GetCurrentProcess().Handle.ToString();
+                string myPid = Process.GetCurrentProcess().Id.ToString();
                 return GetListenSockets(myPid, listenPid, SD_LISTEN_FDS_START, fdCount);
             }
         }


### PR DESCRIPTION
Since .NET Core 3.0, Handle no longer returns the process id.