### PR TITLE
Log logging errors to stderr instead of stdout, along with setting priority

### DIFF
--- a/src/Tmds.Systemd/Journal.cs
+++ b/src/Tmds.Systemd/Journal.cs
@@ -207,7 +207,11 @@ namespace Tmds.Systemd
 
         private static void ErrorWhileLogging(string cause)
         {
-            Console.WriteLine($"Error writing message to journal: {cause}");
+            const string SD_ERR = "<3>";
+            var pri = Console.IsErrorRedirected && ServiceManager.IsRunningAsService 
+                ? SD_ERR 
+                : null;
+            Console.Error.WriteLine("{0}Error writing message to journal: {1}", pri, cause);
         }
 
         private unsafe struct IOVector

--- a/src/Tmds.Systemd/ServiceManager.cs
+++ b/src/Tmds.Systemd/ServiceManager.cs
@@ -67,18 +67,8 @@ namespace Tmds.Systemd
                 }
 
                 // Check process name for the parent process to match "systemd\n"
-                using (var commFile = File.Open("/proc/" + ppidString + "/comm", FileMode.Open, FileAccess.Read, FileShare.Read))
-                {
-                    return commFile.ReadByte() == 's'
-                        && commFile.ReadByte() == 'y'
-                        && commFile.ReadByte() == 's'
-                        && commFile.ReadByte() == 't'
-                        && commFile.ReadByte() == 'e'
-                        && commFile.ReadByte() == 'm'
-                        && commFile.ReadByte() == 'd'
-                        && commFile.ReadByte() == '\n'
-                        && commFile.ReadByte() == -1;
-                }
+                var comm = File.ReadAllBytes("/proc/" + ppidString + "/comm");
+                return comm.AsSpan().SequenceEqual(System.Text.Encoding.ASCII.GetBytes("systemd\n"));
             }
             catch
             {

--- a/src/Tmds.Systemd/ServiceManager.cs
+++ b/src/Tmds.Systemd/ServiceManager.cs
@@ -57,17 +57,17 @@ namespace Tmds.Systemd
             {
                 // Test parent process
                 var parentPid = getppid();
-                var pidString = parentPid.ToString(NumberFormatInfo.InvariantInfo);
+                var ppidString = parentPid.ToString(NumberFormatInfo.InvariantInfo);
 
                 // If parent PID is not 1, this may be a user unit, in this case it must match MANAGERPID envvar
                 if (parentPid != 1
-                    && Environment.GetEnvironmentVariable("MANAGERPID") != pidString)
+                    && Environment.GetEnvironmentVariable("MANAGERPID") != ppidString)
                 {
                     return false;
                 }
 
                 // Check process name for the parent process to match "systemd\n"
-                using (var commFile = File.Open("/proc/" + pidString + "/comm", FileMode.Open, FileAccess.Read, FileShare.Read))
+                using (var commFile = File.Open("/proc/" + ppidString + "/comm", FileMode.Open, FileAccess.Read, FileShare.Read))
                 {
                     return commFile.ReadByte() == 's'
                         && commFile.ReadByte() == 'y'

--- a/src/Tmds.Systemd/ServiceManager.cs
+++ b/src/Tmds.Systemd/ServiceManager.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Globalization;
+using System.IO;
+using System.Runtime.InteropServices;
 
 namespace Tmds.Systemd
 {
@@ -8,12 +11,13 @@ namespace Tmds.Systemd
     public partial class ServiceManager
     {
         private static string _invocationId;
+        private static bool? _isRunningAsService;
         private static readonly object _gate = new object();
 
         /// <summary>
         /// Returns whether the process is running as part of a unit.
         /// </summary>
-        public static bool IsRunningAsService => InvocationId != null;
+        public static bool IsRunningAsService => _isRunningAsService ?? (bool)(_isRunningAsService = CheckServiceManager());
 
         /// <summary>
         /// Returns unique identifier of the runtime cycle of the unit.
@@ -33,5 +37,57 @@ namespace Tmds.Systemd
                 return _invocationId;
             }
         }
+
+        private static bool CheckServiceManager()
+        {
+            // No point in testing anything unless it's Unix
+            if (Environment.OSVersion.Platform != PlatformID.Unix)
+            {
+                return false;
+            }
+
+            // We've got invocation id, it's systemd >= 232 running a unit
+            if (InvocationId != null)
+            {
+                return true;
+            }
+
+            // Either it's not a service, or systemd is < 232, do a bit more digging
+            try
+            {
+                // Test parent process
+                var parentPid = getppid();
+                var pidString = parentPid.ToString(NumberFormatInfo.InvariantInfo);
+
+                // If parent PID is not 1, this may be a user unit, in this case it must match MANAGERPID envvar
+                if (parentPid != 1
+                    && Environment.GetEnvironmentVariable("MANAGERPID") != pidString)
+                {
+                    return false;
+                }
+
+                // Check process name for the parent process to match "systemd\n"
+                using (var commFile = File.Open("/proc/" + pidString + "/comm", FileMode.Open, FileAccess.Read, FileShare.Read))
+                {
+                    return commFile.ReadByte() == 's'
+                        && commFile.ReadByte() == 'y'
+                        && commFile.ReadByte() == 's'
+                        && commFile.ReadByte() == 't'
+                        && commFile.ReadByte() == 'e'
+                        && commFile.ReadByte() == 'm'
+                        && commFile.ReadByte() == 'd'
+                        && commFile.ReadByte() == '\n'
+                        && commFile.ReadByte() == -1;
+                }
+            }
+            catch
+            {
+            }
+
+            return false;
+        }
+
+        [DllImport("libc", SetLastError = true)]
+        private static extern int getppid();
     }
 }


### PR DESCRIPTION
The rationale behind this change is that in most common scenario with this library being used in a systemd-activated service, the failure to log via journald API is still logged via _stdout_, and is not assigned the correct severity, which leads to logging failure being undetected by automated monitoring tools.

One of ways to improve on this, is prefixing such messages with [SD_ERR](https://www.freedesktop.org/software/systemd/man/sd-daemon.html#Description) priority prefix, along with using _stderr_ for output.
On the other hand, adding this prefix in every case seems not robust enough, so I added a couple of checks -- the _stderr_ must be redirected (so running this on console won't have this extra prefix) and the process should be run under an instance of _systemd_. I understand that these checks do not cover 100% of cases, but they look good enough for **most** of them.

Unfortunately older _systemd_ versions (for example the Ubuntu 16.04 has _systemd_ 229) has no direct method of determining if the process is run as a unit, since the `$INVOCATION_ID` envvar [was introduced](https://lists.freedesktop.org/archives/systemd-devel/2016-November/037698.html) in _systemd_ 232. To work around this limitation, I had to expand the `ServiceManager.IsRunningAsService` method to cover older versions. It first performs the original check via the `InvocationId` property, and then, if it's not available, follows up with checking the parent process command using the `getppid(2)` and access to the _/proc/\<pid\>/comm_ file to check if the parent process is, in fact, an instance of _systemd_, along with doing some extra checks for user units via [`$MANAGERPID`](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#Environment%20variables%20in%20spawned%20processes) envvar.
