### PR TITLE
Configuration fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The logger can be configured in `appsettings.json` using the `Journal` alias. Th
     "Microsoft": "Information"
   },
   "Journal": {
-    "IncludeScopes": false,
+    "SyslogIdentifier": "dotnet",
     "LogLevel": {
       "Default": "Warning",
       "System": "Warning",

--- a/src/Tmds.Systemd.Logging/JournalLoggerExtensions.cs
+++ b/src/Tmds.Systemd.Logging/JournalLoggerExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging.Configuration;
 using Tmds.Systemd.Logging;
 using Tmds.Systemd;
 
@@ -19,7 +20,9 @@ namespace Microsoft.Extensions.Logging
         {
             if (Journal.IsSupported)
             {
+                builder.AddConfiguration();
                 builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider, JournalLoggerProvider>());
+                LoggerProviderOptions.RegisterProviderOptions<JournalLoggerOptions, JournalLoggerProvider>(builder.Services);
             }
             return builder;
         }

--- a/src/Tmds.Systemd.Logging/Tmds.Systemd.Logging.csproj
+++ b/src/Tmds.Systemd.Logging/Tmds.Systemd.Logging.csproj
@@ -9,7 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="3.0.0" />
     <ProjectReference Include="..\Tmds.Systemd\Tmds.Systemd.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
I'll be honest I'm not entirely sure what I'm doing with the version numbers here. I only have .NET Core 5.0 installed. The change here seemed to be necessary to load the configuration as expected in the .NET 5.0. I did originally try this with the Target Framework updated to 5.0 as well and that also worked, but I wasn't sure if it was a necessary change so I left it out. I believe the LoggerProviderOptions class is available from 3.0 so I've set the version requirement to that.